### PR TITLE
Add starting-point requirements.txt file and update README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # Custom Exclusions
-*.txt
 ItemQueue/
 RegistrationData/
 logs/

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ python3 -m pip install beautifulsoup4
 
 python3 -m pip install matplotlib
 
+#### Or, install with requirements.txt
+
+```
+pip install -r requirements.txt
+```
+
 ## Commands
 
 |Core Commands|Description|

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+beautifulsoup4
+discord.py
+matplotlib
+numpy
+python-dotenv
+requests
+websocket-client


### PR DESCRIPTION
# Context
To simplify python dependency installation, we can start utilizing `requirement.txt` files

# What Changed
- Added `requirement.txt` file with base dependencies (_I might be missing some, my local env isn't actually set up with the right ENV variables to run everything end-to-end_)
- Updated README with instructions on how to use requirements file

# Verification
- Deleted local .venv directory to have a clean dependency slate
- Created a new virtual env with `python -m venv .venv`
- Installed requirements with `pip install -r requirements.txt`
- Ran program and checked that failures were not due to missing dependencies (only missing env variables teehee)