### PR TITLE
cast deathlink to string to prevent TypeErrors on misformateed responses

### DIFF
--- a/bridgeipelago.py
+++ b/bridgeipelago.py
@@ -468,8 +468,8 @@ async def ProcessDeathQueue():
     else:
         chatmessage = death_queue.get()
         timecode = time.strftime("%Y||%m||%d||%H||%M||%S")
-        DeathMessage = "**Deathlink received from: " + chatmessage['data']['source'] + "**"
-        DeathLogMessage = timecode + "||" + chatmessage['data']['source'] + "\n"
+        DeathMessage = "**Deathlink received from: " + str(chatmessage['data']['source']) + "**"
+        DeathLogMessage = timecode + "||" + str(chatmessage['data']['source']) + "\n"
         o = open(DeathFileLocation, "a")
         o.write(DeathLogMessage)
         o.close()


### PR DESCRIPTION
Fixes typeerror when slotnames are mis-sent as integers rather than text.