### PR TITLE
Add missing UniqueID to bridgeipelago-docker.yaml

### DIFF
--- a/bridgeipelago-docker.yaml
+++ b/bridgeipelago-docker.yaml
@@ -13,6 +13,7 @@ services:
       ArchipelagoBotSlot: Bridgeipelago
       ArchipelagoTrackerURL: https://Archipelago.gg/tracker/<customURLhere>
       ArchipelagoServerURL: https://archipelago.gg/room/<customURLhere>
+      UniqueID: 1234567890
       #---[Item Filter Config]---
       BotItemSpoilTraps: 'true'
       BotItemFilterLevel: 0


### PR DESCRIPTION
When using the docker setup, the application immediately errors due to UniqueID missing from the environment. I assume this was forgotten so adding it to the docker compose setup